### PR TITLE
Update cruip link in page's footer

### DIFF
--- a/src/partials/Footer.js
+++ b/src/partials/Footer.js
@@ -152,7 +152,7 @@ function Footer() {
           </ul>
 
           {/* Copyrights note */}
-          <div className="text-sm text-gray-600 mr-4">Made by <a className="text-blue-600 hover:underline" href="https://cruip.con/">Cruip</a>. All rights reserved.</div>
+          <div className="text-sm text-gray-600 mr-4">Made by <a className="text-blue-600 hover:underline" href="https://cruip.com/">Cruip</a>. All rights reserved.</div>
 
         </div>
 


### PR DESCRIPTION
The `href` inside the footer's copyrights note went to `cruip.con` when I wanted to visit it. So this is just a quick typo fix