### PR TITLE
Don't fix height of tab items.

### DIFF
--- a/components/features.tsx
+++ b/components/features.tsx
@@ -12,14 +12,6 @@ export default function Features() {
 
   const tabs = useRef<HTMLDivElement>(null)
 
-  const heightFix = () => {
-    if (tabs.current && tabs.current.parentElement) tabs.current.parentElement.style.height = `${tabs.current.clientHeight}px`
-  }
-
-  useEffect(() => {
-    heightFix()
-  }, []) 
-
   return (
     <section className="relative">
 


### PR DESCRIPTION
Height fixing makes components overlap on mobile and small width window sizes.

Fixes https://github.com/cruip/tailwind-landing-page-template/issues/30.