### PR TITLE
Fix banner z-index.

### DIFF
--- a/components/banner.tsx
+++ b/components/banner.tsx
@@ -9,7 +9,7 @@ export default function Banner() {
   return (
     <>
       {bannerOpen && (
-        <div className="fixed bottom-0 right-0 w-full md:bottom-8 md:right-12 md:w-auto z-60">
+        <div className="fixed bottom-0 right-0 w-full md:bottom-8 md:right-12 md:w-auto z-50">
           <div className="bg-slate-800 text-slate-50 text-sm p-3 md:rounded shadow-lg flex justify-between">
             <div className='text-slate-500 inline-flex'><a className="font-medium hover:underline text-slate-50" href="https://github.com/cruip/tailwind-landing-page-template" target="_blank" rel="noreferrer">Download<span className="hidden sm:inline"> on GitHub</span></a> <span className="italic px-1.5">or</span> <a className="font-medium hover:underline text-emerald-400" href="https://cruip.com/simple/" target="_blank" rel="noreferrer">Check Premium Version</a></div>
             <button className="text-slate-500 hover:text-slate-400 pl-2 ml-3 border-l border-gray-700" onClick={() => setBannerOpen(false)}>


### PR DESCRIPTION
Hi, I noticed that the banner currently uses a z-index of z-60. However, according to the official documentation, the maximum z-index is z-50.

Official Tailwind CSS documentation regarding z-index values: [https://tailwindcss.com/docs/z-index](https://tailwindcss.com/docs/z-index)